### PR TITLE
Fix important typo (core test set of TIMIT)

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ TODO
 
 ### TIMIT
 
-(So far, all results trained on TIMIT and tested on the standard test set.)
+(So far, all results trained on TIMIT and tested on the core test set.)
 
 | PER     | Paper  | Published | Notes   |
 | :------ | :----- | :-------- | :-----: |


### PR DESCRIPTION
At least papers Graves et al. 2013 and Vanek et al. 2017 use the core test set and not the full test set. This is a standard way of testing on TIMIT and I assume every paper uses this. Otherwise, the scores are not consistent and can not be compared.